### PR TITLE
Update the configs to match what is called in the Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Please see the [Base Installation Guide](https://socialiteproviders.com/usage/),
 'stackexchange' => [    
   'client_id' => env('STACKEXCHANGE_CLIENT_ID'),  
   'client_secret' => env('STACKEXCHANGE_CLIENT_SECRET'),  
+  'key' => env('STACKEXCHANGE_CLIENT_KEY'),
+  'site' => env('STACKEXCHANGE_CLIENT_SITE', 'stackoverflow'),
   'redirect' => env('STACKEXCHANGE_REDIRECT_URI') 
 ],
 ```


### PR DESCRIPTION
Provider.php calls for keys `site` and `key` from the config. The `key` id different from the `client_id` and it needs both. When you go https://stackapps.com/apps/oauth/register it issues an Id, Key, and Secret. 

The site needs to be one of their providers: `stackoverflow` works.